### PR TITLE
refactor: unify the interface for both TESTICP and ICRC1

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -11,22 +11,15 @@
       "type": "custom",
       "candid": "https://github.com/dfinity/ic/releases/download/ledger-suite-icrc-2025-06-19/ledger.did",
       "wasm": "https://github.com/dfinity/ic/releases/download/ledger-suite-icrc-2025-06-19/ic-icrc1-ledger.wasm.gz",
-      "init_arg": "(variant { Init = record { token_symbol = \"TICRC1\"; token_name = \"ICRC1 Test Token\"; minting_account = record { owner = principal \"pwwqf-yaaaa-aaaap-qp5wq-cai\"; }; transfer_fee = 1000; metadata = vec {}; initial_balances = vec { }; archive_options = record { num_blocks_to_archive = 1000000; trigger_threshold = 2000000; controller_id = principal \"2vxsx-fae\"; cycles_for_archive_creation = opt 10_000_000_000_000; } } })",
+      "init_arg": "(variant { Init = record { token_symbol = \"TICRC1\"; token_name = \"ICRC1 Test Token\"; minting_account = record { owner = principal \"nqoci-rqaaa-aaaap-qp53q-cai\"; }; transfer_fee = 1000; metadata = vec {}; initial_balances = vec { }; archive_options = record { num_blocks_to_archive = 1000000; trigger_threshold = 2000000; controller_id = principal \"2vxsx-fae\"; cycles_for_archive_creation = opt 10_000_000_000_000; } } })",
       "specified_id": "3jkp5-oyaaa-aaaaj-azwqa-cai"
     },
-    "testicp": {
+    "faucet": {
       "type": "custom",
       "candid": "./src/backend/backend.did",
-      "init_arg": "(record { ledger_canister = principal \"xafvr-biaaa-aaaai-aql5q-cai\"; ledger_type = variant { ICP }; is_mint = true; })",
+      "init_arg": "(record { icp_ledger = record { canister_id = principal \"xafvr-biaaa-aaaai-aql5q-cai\"; is_mint = true }; icrc1_ledger = record { canister_id = principal \"3jkp5-oyaaa-aaaaj-azwqa-cai\"; is_mint = true }; })",
       "wasm": "./target/wasm32-unknown-unknown/release/backend.wasm.gz",
       "specified_id": "nqoci-rqaaa-aaaap-qp53q-cai"
-    },
-    "ticrc1": {
-      "type": "custom",
-      "candid": "./src/backend/backend.did",
-      "init_arg": "(record { ledger_canister = principal \"3jkp5-oyaaa-aaaaj-azwqa-cai\"; ledger_type = variant { ICRC1 }; is_mint = true; })",
-      "wasm": "./target/wasm32-unknown-unknown/release/backend.wasm.gz",
-      "specified_id": "pwwqf-yaaaa-aaaap-qp5wq-cai"
     }
   },
   "defaults": {

--- a/justfile
+++ b/justfile
@@ -1,47 +1,20 @@
-# Start development server with ICP token type
-start-icp:
-  cd src/frontend && VITE_TOKEN_SYMBOL=TESTICP npm run start
-
-# Start development server with ICRC1 token type
-start-icrc1:
-  cd src/frontend && VITE_TOKEN_SYMBOL=TICRC1 npm run start
-
-# Deploy a specific token
-build token_type:
+build:
   #!/usr/bin/env bash
   # Build frontend
-  if [ "{{token_type}}" = "testicp" ]; then
-    cd src/frontend && npm install && VITE_TOKEN_SYMBOL=TESTICP npm run build:icp
-    cd ../../
-  elif [ "{{token_type}}" = "ticrc1" ]; then
-    cd src/frontend && npm install && VITE_TOKEN_SYMBOL=TICRC1 npm run build:icrc1
-    cd ../../
-  else
-    echo "Error: Please specify 'testicp' or 'ticrc1'"
-    exit 1
-  fi
+  cd src/frontend && npm install && npm run build
+  cd ../..
 
   # Build and compress backend.
   cargo build --target wasm32-unknown-unknown --release --features frontend
   gzip -n -f "./target/wasm32-unknown-unknown/release/backend.wasm"
 
 # Deploy a specific token
-deploy token_type: (build token_type)
+deploy: build
   #!/usr/bin/env bash
-  if [ "{{token_type}}" = "testicp" ]; then
-    # Deploy canisters
-    dfx deploy testicp-ledger
-    dfx deploy testicp --mode=reinstall -y
-  elif [ "{{token_type}}" = "ticrc1" ]; then
-    # Deploy canisters
-    dfx deploy ticrc1-ledger
-    dfx deploy ticrc1 --mode=reinstall -y
-  else
-    echo "Error: Please specify 'testicp' or 'ticrc1'"
-    echo "Usage: just deploy testicp"
-    echo "       just deploy ticrc1"
-    exit 1
-  fi
+  # Deploy canisters
+  dfx deploy testicp-ledger
+  dfx deploy ticrc1-ledger
+  dfx deploy faucet --mode=reinstall -y
 
 deploy-backend-only token_type:
   #!/usr/bin/env bash

--- a/src/backend/backend.did
+++ b/src/backend/backend.did
@@ -1,12 +1,11 @@
-type ledger_type = variant {
-    ICRC1;
-    ICP;
+type ledger_config = record {
+    canister_id: principal;
+    is_mint: bool;
 };
 
 type init_args = record {
-    ledger_canister: principal;
-    ledger_type: ledger_type;
-    is_mint: bool;
+    icp_ledger: ledger_config;
+    icrc1_ledger: ledger_config;
 };
 
 service: (init_args) -> {

--- a/src/declarations/faucet/faucet.did
+++ b/src/declarations/faucet/faucet.did
@@ -1,12 +1,11 @@
-type ledger_type = variant {
-    ICRC1;
-    ICP;
+type ledger_config = record {
+    canister_id: principal;
+    is_mint: bool;
 };
 
 type init_args = record {
-    ledger_canister: principal;
-    ledger_type: ledger_type;
-    is_mint: bool;
+    icp_ledger: ledger_config;
+    icrc1_ledger: ledger_config;
 };
 
 service: (init_args) -> {

--- a/src/declarations/faucet/faucet.did.d.ts
+++ b/src/declarations/faucet/faucet.did.d.ts
@@ -3,12 +3,13 @@ import type { ActorMethod } from '@dfinity/agent';
 import type { IDL } from '@dfinity/candid';
 
 export interface init_args {
-  'is_mint' : boolean,
-  'ledger_type' : ledger_type,
-  'ledger_canister' : Principal,
+  'icp_ledger' : ledger_config,
+  'icrc1_ledger' : ledger_config,
 }
-export type ledger_type = { 'ICP' : null } |
-  { 'ICRC1' : null };
+export interface ledger_config {
+  'is_mint' : boolean,
+  'canister_id' : Principal,
+}
 export interface _SERVICE {
   'account_identifier' : ActorMethod<[], string>,
   'transfer_icp' : ActorMethod<[string], undefined>,

--- a/src/declarations/faucet/faucet.did.js
+++ b/src/declarations/faucet/faucet.did.js
@@ -1,9 +1,11 @@
 export const idlFactory = ({ IDL }) => {
-  const ledger_type = IDL.Variant({ 'ICP' : IDL.Null, 'ICRC1' : IDL.Null });
-  const init_args = IDL.Record({
+  const ledger_config = IDL.Record({
     'is_mint' : IDL.Bool,
-    'ledger_type' : ledger_type,
-    'ledger_canister' : IDL.Principal,
+    'canister_id' : IDL.Principal,
+  });
+  const init_args = IDL.Record({
+    'icp_ledger' : ledger_config,
+    'icrc1_ledger' : ledger_config,
   });
   return IDL.Service({
     'account_identifier' : IDL.Func([], [IDL.Text], ['query']),
@@ -12,11 +14,13 @@ export const idlFactory = ({ IDL }) => {
   });
 };
 export const init = ({ IDL }) => {
-  const ledger_type = IDL.Variant({ 'ICP' : IDL.Null, 'ICRC1' : IDL.Null });
-  const init_args = IDL.Record({
+  const ledger_config = IDL.Record({
     'is_mint' : IDL.Bool,
-    'ledger_type' : ledger_type,
-    'ledger_canister' : IDL.Principal,
+    'canister_id' : IDL.Principal,
+  });
+  const init_args = IDL.Record({
+    'icp_ledger' : ledger_config,
+    'icrc1_ledger' : ledger_config,
   });
   return [init_args];
 };

--- a/src/declarations/faucet/index.d.ts
+++ b/src/declarations/faucet/index.d.ts
@@ -7,7 +7,7 @@ import type {
 import type { Principal } from "@dfinity/principal";
 import type { IDL } from "@dfinity/candid";
 
-import { _SERVICE } from './testicp.did';
+import { _SERVICE } from './faucet.did';
 
 export declare const idlFactory: IDL.InterfaceFactory;
 export declare const canisterId: string;
@@ -47,4 +47,4 @@ export declare const createActor: (
  * Intialized Actor using default settings, ready to talk to a canister using its candid interface
  * @constructs {@link ActorSubClass}
  */
-export declare const testicp: ActorSubclass<_SERVICE>;
+export declare const faucet: ActorSubclass<_SERVICE>;

--- a/src/declarations/faucet/index.js
+++ b/src/declarations/faucet/index.js
@@ -1,8 +1,8 @@
 import { Actor, HttpAgent } from "@dfinity/agent";
 
 // Imports and re-exports candid interface
-import { idlFactory } from "./testicp.did.js";
-export { idlFactory } from "./testicp.did.js";
+import { idlFactory } from "./faucet.did.js";
+export { idlFactory } from "./faucet.did.js";
 
 /* CANISTER_ID is replaced by webpack based on node environment
  * Note: canister environment variable will be standardized as
@@ -10,7 +10,7 @@ export { idlFactory } from "./testicp.did.js";
  * beginning in dfx 0.15.0
  */
 export const canisterId =
-  process.env.CANISTER_ID_TESTICP;
+  process.env.CANISTER_ID_FAUCET;
 
 export const createActor = (canisterId, options = {}) => {
   const agent = options.agent || new HttpAgent({ ...options.agentOptions });
@@ -39,4 +39,4 @@ export const createActor = (canisterId, options = {}) => {
   });
 };
 
-export const testicp = canisterId ? createActor(canisterId) : undefined;
+export const faucet = canisterId ? createActor(canisterId) : undefined;

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8" />
   <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>%VITE_TOKEN_SYMBOL% Token Faucet</title>
+  <title>IC Token Faucet</title>
 </head>
 
 <body>

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -5,11 +5,9 @@
   "type": "module",
   "scripts": {
     "start": "VITE_TOKEN_SYMBOL=TICRC1 vite --port 3000",
-    "start:icp": "VITE_TOKEN_SYMBOL=TESTICP VITE_CANISTER_ID=nqoci-rqaaa-aaaap-qp53q-cai vite --port 3000",
-    "start:icrc1": "VITE_TOKEN_SYMBOL=TICRC1 VITE_CANISTER_ID=pwwqf-yaaaa-aaaap-qp5wq-cai vite --port 3000",
-    "prebuild": "dfx generate testicp",
-    "build:icp": "VITE_TOKEN_SYMBOL=TESTICP VITE_CANISTER_ID=nqoci-rqaaa-aaaap-qp53q-cai vite build --outDir dist",
-    "build:icrc1": "VITE_TOKEN_SYMBOL=TICRC1 VITE_CANISTER_ID=pwwqf-yaaaa-aaaap-qp5wq-cai vite build --outDir dist",
+    "start:unified": "VITE_CANISTER_ID=nqoci-rqaaa-aaaap-qp53q-cai vite --port 3000",
+    "prebuild": "dfx generate faucet",
+    "build": "VITE_CANISTER_ID=nqoci-rqaaa-aaaap-qp53q-cai vite build --outDir dist",
     "format": "prettier --write \"src/**/*.{json,js,jsx,ts,tsx,css,scss}\""
   },
   "devDependencies": {

--- a/src/frontend/src/index.scss
+++ b/src/frontend/src/index.scss
@@ -54,6 +54,11 @@ label {
   text-align: left;
 }
 
+form label {
+  max-width: 400px;
+  margin: 0 auto 0.5rem auto;
+}
+
 input[type="text"] {
   width: 100%;
   max-width: 400px;
@@ -197,6 +202,69 @@ button:disabled {
   }
 }
 
+/* Token Selection Styling */
+.token-selection {
+  margin: 1.5rem 0;
+}
+
+.token-selection h3 {
+  margin-bottom: 1rem;
+  color: #333;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.token-options {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.token-option {
+  display: flex;
+  align-items: center;
+  padding: 1rem;
+  border: 2px solid #e9ecef;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  background: white;
+  min-width: 120px;
+}
+
+.token-option:hover {
+  border-color: #29ABE2;
+  background: #f8f9ff;
+}
+
+.token-option.selected {
+  border-color: #29ABE2;
+  background: linear-gradient(135deg, #e8f4fd 0%, #f0f8ff 100%);
+  box-shadow: 0 2px 8px rgba(41, 171, 226, 0.2);
+}
+
+.token-option input[type="radio"] {
+  display: none;
+}
+
+.token-label {
+  text-align: left;
+}
+
+.token-label strong {
+  display: block;
+  color: #333;
+  font-size: 1rem;
+  margin-bottom: 0.25rem;
+}
+
+.token-label small {
+  color: #666;
+  font-size: 0.85rem;
+}
+
+
 @media (max-width: 600px) {
   main {
     margin: 1rem;
@@ -213,5 +281,15 @@ button:disabled {
   
   .info {
     padding: 1rem;
+  }
+
+  .token-options {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .token-option {
+    width: 100%;
+    max-width: 250px;
   }
 }


### PR DESCRIPTION
This update further simplifies the design of the token faucet. Earlier, we merged the frontend and backend into one canister, reducing the number of canisters from four to two (one for TESTICP and another for TICRC1). Now we merge the frontend to support both tokens, so that now we have one canister, simplifying code, documentation, and discoverability.