### PR TITLE
chore: add candid metadata to canister wasm

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Which can be computed as:
    click "See all" in the "Performed calls" window on the bottom-right. For the "Test ICP Ledger", one such example is
     on 2025-06-26 (set this date as the "From" and "To" dates):
 
+```
 (
   record {
     to = record {
@@ -152,6 +153,7 @@ Which can be computed as:
     amount = 10_000_000_000 : nat;
   },
 )
+```
 
 4. Modify the above transfer arguments as needed. E.g., to mint enough for a faucet to give out 10 tokens
    (1_000_000_000) every second for the next 10 years (60*60*24*365*10=315360000), set the amount to

--- a/justfile
+++ b/justfile
@@ -4,8 +4,16 @@ build:
   cd src/frontend && npm install && npm run build
   cd ../..
 
-  # Build and compress backend.
   cargo build --target wasm32-unknown-unknown --release --features frontend
+
+  # Add canister metadata
+  cargo binstall ic-wasm --version 0.9.6 --root ./target
+  ./target/bin/ic-wasm \
+      "./target/wasm32-unknown-unknown/release/backend.wasm" \
+      -o "./target/wasm32-unknown-unknown/release/backend.wasm" \
+      metadata candid:service -f "./src/backend/backend.did" -v public
+
+  # Compress
   gzip -n -f "./target/wasm32-unknown-unknown/release/backend.wasm"
 
 # Deploy a specific token


### PR DESCRIPTION
Without this change, the dashboard does not expose the candid endpoints of the canister.